### PR TITLE
Update .gitignore for Godot 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Godot 4+ specific ignores
+.godot/
+
 # Godot-specific ignores
 .import/
 export.cfg
@@ -9,3 +12,4 @@ export_presets.cfg
 # Mono-specific ignores
 .mono/
 data_*/
+mono_crash.*.json


### PR DESCRIPTION
Before this change, this project was using a [gitignore][1] file that was meant for Godot 3 or lower. As a result, some files that should have been ignored by Git weren’t ignored by Git.

This change also removes the extra files (the ones that should have been ignored previously).

[1]: <https://git-scm.com/docs/gitignore>